### PR TITLE
Fix/missing data in charts

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -16,7 +16,7 @@ class DashboardsController < ApplicationController
     @slices = @dashboard.widgets.select {|widget|
       widget.has_data?
     }.collect {|widget|
-      widget.data_table.slices(widget, limit: 13)
+      widget.data_table.decorate.slices(widget, limit: 13)
     }.flatten
   end
 

--- a/app/decorators/data_table_decorator.rb
+++ b/app/decorators/data_table_decorator.rb
@@ -13,15 +13,17 @@ class DataTableDecorator < Draper::Decorator
     end
   end
 
-  # Use period start rather than first blank period to get slices
+  #TODO find a way of DRYing this up, copy-pasted just to use 
   def slices(widget, limit: 0)
     arr = []
 
     if period_start = series_end&.beginning_of_month
       while (0 == limit || arr.size < limit) &&
-          period_start >= series_start&.beginning_of_month &&   
-          s = slice_data(widget, 'month', period_start)
-        arr << s
+          period_start >= series_start&.beginning_of_month
+        if s = slice_data(widget, 'month', period_start)
+          arr << s          
+        end
+
         period_start = period_start << 1
       end
     end

--- a/app/models/data_table.rb
+++ b/app/models/data_table.rb
@@ -49,8 +49,11 @@ class DataTable < ApplicationRecord
 
     if period_start = series_end&.beginning_of_month
       while (0 == limit || arr.size < limit) &&
-          s = slice_data(widget, 'month', period_start)
-        arr << s
+          period_start >= series_start&.beginning_of_month
+        if s = slice_data(widget, 'month', period_start)
+          arr << s          
+        end
+
         period_start = period_start << 1
       end
     end


### PR DESCRIPTION
Problem was data was entered only for latest month after a long gap, and the way slices were retrieved was not able to cope with this. 

This problem affected the public facing dashboards and also the editor. 

This fixes the problem by: 
- Public facing side, make slices from virtual data rows 
- Editor side, just send all available slices regardless of any gaps in data