### PR TITLE
Autolinking for dashboard.note.body

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem 'activerecord-session_store'
 gem 'storext', '~> 2.2'
 gem 'rollbar', '~> 2.14'
 gem 'semantic', '~> 1.6.0'
+gem 'rinku', '~> 2.0'
 
 group :production do
   gem 'rails_12factor'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -364,6 +364,7 @@ GEM
     request_store (1.3.1)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
+    rinku (2.0.3)
     rollbar (2.14.1)
       multi_json
     rotp (3.3.0)
@@ -510,6 +511,7 @@ DEPENDENCIES
   rails-observers!
   rails_12factor
   redcarpet (~> 3.3)
+  rinku (~> 2.0)
   rollbar (~> 2.14)
   rqrcode-rails3!
   rspec-collection_matchers

--- a/app/decorators/dashboard_decorator.rb
+++ b/app/decorators/dashboard_decorator.rb
@@ -29,7 +29,7 @@ class DashboardDecorator < Draper::Decorator
   end
 
   def notes_to_html
-    h.sanitize(markdown.render(notes))
+    h.sanitize(markdown.render(object.notes))
   end
 
   def name

--- a/app/decorators/dashboard_decorator.rb
+++ b/app/decorators/dashboard_decorator.rb
@@ -10,7 +10,14 @@ class DashboardDecorator < Draper::Decorator
   end
 
   def show_notes?
-    notes.present?
+    object.notes.present?
+  end
+
+  def notes 
+    object.notes.collect do |note| 
+      note['body'] = Rinku.auto_link note['body']
+      note
+    end
   end
 
   def show_url?

--- a/app/views/dashboards/_notes.html.erb
+++ b/app/views/dashboards/_notes.html.erb
@@ -1,7 +1,7 @@
 <dl>
   <% dashboard.notes.each do |note| %>
     <dt><%= note['title'] %></dt>
-    <dd><%= note['body'] %></dd>
+    <dd><%== note['body'] %></dd>
     <% if note['list'] %>
       <ul style='margin-top:0'>
         <% note['list'].each do |item| %>


### PR DESCRIPTION
Some changes to the Marketplace dashboard require there to be a link in the notes for the dashboard. This PR allows URLs in the notes to be automatically rendered as hyperlinked.

I've noticed that there's some markdown parsing/rendering code in the decorator for dashboard objects; although this is currently unused (a feature started and abandoned?) this may be a better way to go in future. But that would involve a migration of the existing data (which is currently in JSON), which would be time-consuming to manage the risk - so best leave that till we have time to do it properly.