### PR TITLE
Disable action view logger by default in prod/cf

### DIFF
--- a/config/environments/cloudfoundry.rb
+++ b/config/environments/cloudfoundry.rb
@@ -51,6 +51,11 @@ Rails.application.configure do
   # when problems arise.
   config.log_level = :debug
 
+  # Action view logger generates a lot of log messages, so disable it by default
+  unless ENV["ENABLE_ACTION_VIEW_LOGGER"].present?
+    config.action_view.logger = nil
+  end
+
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -87,6 +87,11 @@ Rails.application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
 
+  # Action view logger generates a lot of log messages, so disable it by default
+  unless ENV["ENABLE_ACTION_VIEW_LOGGER"].present?
+    config.action_view.logger = nil
+  end
+
   # Use a different logger for distributed setups.
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')


### PR DESCRIPTION
We recently noticed that dashboard.gov.au is generating a lot of logs compared to other apps on cloud.gov.au. We had a look, and e.g. on one visit to the root index page, there are 1001 log messages, and 996 are logs from the asset view logger saying rendered. Just thought I'd suggest this change of disabling these logs by default, and then re-enabling with an env variable when you notice an issue and need to see the entries.